### PR TITLE
13 short term tasks from backend

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,8 +1,8 @@
-VITE_BACKEND_URL=http://127.0.0.1:5000
+VITE_BACKEND_URL=http://127.0.0.1:3308
 
-# Make a file called .env.development in the root directory of the 
+# Create a file called .env.development in the root directory of the 
 # project, defining VITE_BACKEND_URL as above. The port at the end 
-# (5000 in the example above) should be the port the Flask app is 
-# running on in Docker. You may have to change it to 3308 or something 
-# else if another process is occupying 5000. (I do). Just make sure it 
-# is the same between frontend and backend.
+# (3308 in the example above) should be the port the Flask app is 
+# running on in Docker. You may have to change it to something else if 
+# another process is occupying 3308 (unlikely). Just make sure it is 
+# the same between frontend and backend.

--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,8 @@
+VITE_BACKEND_URL=http://127.0.0.1:5000
+
+# Make a file called .env.development in the root directory of the 
+# project, defining VITE_BACKEND_URL as above. The port at the end 
+# (5000 in the example above) should be the port the Flask app is 
+# running on in Docker. You may have to change it to 3308 or something 
+# else if another process is occupying 5000. (I do). Just make sure it 
+# is the same between frontend and backend.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env*
+!.env*.example

--- a/src/components/TaskArea/ShortTermTasks/ShortTermTasks.module.css
+++ b/src/components/TaskArea/ShortTermTasks/ShortTermTasks.module.css
@@ -1,3 +1,5 @@
 .shortTermTasksDiv {
   height: 70%;
+  display: flex;
+  flex-direction: column;
 }

--- a/src/components/TaskArea/ShortTermTasks/ShortTermTasks.tsx
+++ b/src/components/TaskArea/ShortTermTasks/ShortTermTasks.tsx
@@ -1,9 +1,31 @@
+import { useEffect } from 'react';
+import useGetRequest from '../../../hooks/useGetRequest';
+import { TaskData } from '../../../types';
 import styles from './ShortTermTasks.module.css';
 
 const ShortTermTasks = () => {
+  const { data, error, loading, sendRequest } = useGetRequest<TaskData[]>('tasks');
+
+  useEffect(() => {
+    sendRequest({ task_type: 'short-term' });
+  }, [sendRequest]);
+
   return (
     <div className={`${styles.shortTermTasksDiv} placeholderDiv`}>
-      <p>Here is where short-term tasks will go!</p>
+      {loading && <p>Loading...</p>}
+      {error && <p>Failed to get tasks: {error.message}</p>}
+      {data && (
+        <>
+          {data.map((task) => (
+            <div key={task.id}>
+              <label>
+                <input type='checkbox' checked={task.task_complete} />
+                {task.task_name}
+              </label>
+            </div>
+          ))}
+        </>
+      )}
     </div>
   );
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const backendUrl = import.meta.env.VITE_BACKEND_URL;

--- a/src/hooks/useGetRequest.ts
+++ b/src/hooks/useGetRequest.ts
@@ -31,7 +31,7 @@ const useGetRequest = <TResponse>(endpoint: string) => {
       const queryString = new URLSearchParams(queryParams).toString();
 
       try {
-        const response = await fetch(`${backendUrl}/${endpoint}/${queryString}`, {
+        const response = await fetch(`${backendUrl}/${endpoint}?${queryString}`, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/src/hooks/useGetRequest.ts
+++ b/src/hooks/useGetRequest.ts
@@ -1,0 +1,58 @@
+import { useState, useCallback } from 'react';
+import { backendUrl } from '../config';
+
+/**
+ * Custom hook for making GET requests to the backend with query parameters.
+ *
+ * @template TResponse - The expected response type.
+ * @param endpoint - The API endpoint. Do not include the base URL or, leading slash, or
+ *                   parameters. Correct endpoint example: "tasks"
+ * @returns { data, error, loading, sendRequest }
+ *          data - The expected TResponse or null.
+ *          error - Any error encountered or null.
+ *          loading - Whether the request is currently in progress.
+ *          sendRequest - The function to trigger the request.
+ */
+const useGetRequest = <TResponse>(endpoint: string) => {
+  const [data, setData] = useState<TResponse | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  /**
+   * Sends a GET request using the specified query parameters.
+   * 
+   * @param queryParams - An object representing the query parameters.
+   */
+  const sendRequest = useCallback(
+    async (queryParams: Record<string, string>) => {
+      setLoading(true);
+      setError(null);
+
+      const queryString = new URLSearchParams(queryParams).toString();
+
+      try {
+        const response = await fetch(`${backendUrl}/${endpoint}/${queryString}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`HTTP ${response.status}: ${errorText}`);
+        }
+        const responseData = await response.json();
+        setData(responseData);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [endpoint],
+  );
+
+  return { data, error, loading, sendRequest };
+};
+
+export default useGetRequest;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
-type taskType = 'long-term' | 'short-term' | 'daily';
+type TaskType = 'long-term' | 'short-term' | 'daily';
 
-export type taskData = {
+export type TaskData = {
   created_date: string;
   due_date: string;
   id: number;
   task_complete: boolean;
   task_name: string;
   task_renewed: boolean;
-  task_type: taskType;
+  task_type: TaskType;
   user_id: number;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+type taskType = 'long-term' | 'short-term' | 'daily';
+
+export type taskData = {
+  created_date: string;
+  due_date: string;
+  id: number;
+  task_complete: boolean;
+  task_name: string;
+  task_renewed: boolean;
+  task_type: taskType;
+  user_id: number;
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // List all environment variables here
+  readonly VITE_BACKEND_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Issue: #13 

- This PR creates a basic list of all short-term tasks in the short-term tasks area. There are checkboxes, but they're currently read only since we don't have POST/PUT/PATCH requests set up. (Each task appears three times because it just gets all short-term tasks, and there are three different users with the same short-term tasks.) 
- This PR also is the first that involves making API requests to the backend. The new custom hook `useGetRequest` performs this task. The backend URL is retrieved from an environment variable, so please see `.env.development.example` for instructions on setting this up. 

### Testing this out

- You should probably test this out alongside the backend PR that sets up CORS to confirm that they both work correctly with each other. 