### PR TITLE
19 signup page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,15 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import './App.css';
 import TaskPage from './pages/TaskPage/TaskPage';
 import LoginPage from './pages/LoginPage/LoginPage';
+import SignupPage from './pages/SignupPage/SignupPage';
 
 const App = () => {
   return (
     <Router>
       <Routes>
         <Route path='/' element={<TaskPage />} />
-        <Route path='/login' element={< LoginPage/>} />
+        <Route path='/login' element={<LoginPage />} />
+        <Route path='/signup' element={<SignupPage />} />
       </Routes>
     </Router>
   );

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,88 +1,100 @@
-import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
-import AuthService from "../../utils/Auth";
-import usePostRequest from "../../hooks/usePostRequest";
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import AuthService from '../../utils/Auth';
+import usePostRequest from '../../hooks/usePostRequest';
+import { AuthUserData } from '../../types';
 
 // TO DO: This is just a quick and dirty login, add style and such
 const LoginPage = () => {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [user, setUser] = useState<any>(null);
+  const [user, setUser] = useState<AuthUserData | null>(null);
   const navigate = useNavigate();
-  const { sendRequest, loading } = usePostRequest<{ token: string }>("login");
+  const { sendRequest, loading } = usePostRequest<{ token: string }>('login');
 
-// Check if user is already logged in
+  // Check if user is already logged in
   useEffect(() => {
     const loggedInUser = AuthService.getUser();
-    console.log("Retrieved User:", loggedInUser);
+    console.log('Retrieved User:', loggedInUser);
     if (loggedInUser) {
       setUser(loggedInUser);
     }
   }, []);
 
-// Handle login form submission
+  // Handle login form submission
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-// Send login request
+    // Send login request
     const response = await sendRequest({ email, password });
 
     if (response && response.token) {
-      console.log("Received Token:", response.token);
+      console.log('Received Token:', response.token);
 
-// Store token and update user state
+      // Store token and update user state
       AuthService.login(response.token);
       setUser(AuthService.getUser());
-// Redirect to home
-      navigate("/");
+      // Redirect to home
+      navigate('/');
     } else {
-      setError("Invalid email or password");
+      setError('Invalid email or password');
     }
   };
 
-// Show user info if logged in
+  // Show user info if logged in
   if (user) {
     return (
       <div>
-        <h2>Welcome, {user.first_name} {user.last_name}!</h2>
+        <h2>
+          Welcome, {user.first_name} {user.last_name}!
+        </h2>
         <p>Email: {user.email}</p>
-        <button onClick={() => { AuthService.logout(); setUser(null); }}>
+        <button
+          onClick={() => {
+            AuthService.logout();
+            setUser(null);
+          }}
+        >
           Logout
         </button>
       </div>
     );
   }
 
-// Show login form if user is NOT logged in
+  // Show login form if user is NOT logged in
   return (
-    <div>
+    <>
       <h2>Login</h2>
 
       {error && <p>{error}</p>}
 
       <form onSubmit={handleSubmit}>
-        <label>Email:</label>
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
-
-        <label>Password:</label>
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
-
-        <button type="submit" disabled={loading}>
-          {loading ? "Logging in..." : "Login"}
+        <label>
+          Email:{' '}
+          <input type='email' value={email} onChange={(e) => setEmail(e.target.value)} required />
+        </label>
+        <br />
+        <label>
+          Password:{' '}
+          <input
+            type='password'
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <br />
+        <button type='submit' disabled={loading}>
+          {loading ? 'Logging in...' : 'Login'}
         </button>
       </form>
-    </div>
+      {/* Direct unregistered users to the signup page */}
+      <h4>No account?</h4>
+      <button type='button' onClick={() => navigate('/signup')}>
+        Sign up
+      </button>
+    </>
   );
 };
 

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -1,0 +1,104 @@
+import { useNavigate } from 'react-router-dom';
+import AuthService from '../../utils/Auth';
+import { useState } from 'react';
+import usePostPutPatchDelete from '../../hooks/usePostPutPatchDelete';
+import { UserInfo, UserSignupUpdateResponse } from '../../types';
+
+const SignupPage = () => {
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { data, error, loading, sendRequest } = usePostPutPatchDelete<
+    UserInfo,
+    UserSignupUpdateResponse
+  >('signup', 'POST');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const info: UserInfo = {
+      username: username,
+      first_name: firstName,
+      last_name: lastName,
+      email: email,
+      password: password,
+    };
+    sendRequest(info);
+  };
+
+  // The user should not be able to create a new account while currently logged in
+  if (AuthService.loggedIn()) {
+    return (
+      <>
+        <p>You're already logged in!</p>
+        <button type='button' onClick={() => AuthService.logout()}>
+          Log out
+        </button>
+        <button type='button' onClick={() => navigate('/')}>
+          Back home
+        </button>
+      </>
+    );
+  }
+
+  // Show the sign up form if the user hasn't signed up yet
+  if (!data) {
+    return (
+      <form onSubmit={handleSubmit}>
+        <h2>Create a new account</h2>
+        <label>
+          First name:{' '}
+          <input value={firstName} onChange={(e) => setFirstName(e.target.value)} required />
+        </label>
+        <br />
+        <label>
+          Last name:{' '}
+          <input value={lastName} onChange={(e) => setLastName(e.target.value)} required />
+        </label>
+        <br />
+        <label>
+          Username:{' '}
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+            autoFocus
+          />
+        </label>
+        <br />
+        <label>
+          Email:{' '}
+          <input type='email' value={email} onChange={(e) => setEmail(e.target.value)} required />
+        </label>
+        <br />
+        <label>
+          Password:{' '}
+          <input
+            type='password'
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <br />
+        <button type='submit'>Sign up</button>
+      </form>
+    );
+  }
+
+  // These return statements are reached after the user has clicked sign up
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error creating account: {error.message}</p>;
+  return (
+    <>
+      <h3>Successfully created account</h3>
+      <button type='button' onClick={() => navigate('/login')}>
+        Log in
+      </button>
+    </>
+  );
+};
+
+export default SignupPage;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,3 +22,16 @@ export type PostTaskRequired = {
   task_type: TaskType;
   due_date: Date;
 };
+
+export type UserInfo = {
+  username: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  password: string;
+};
+
+export type UserSignupUpdateResponse = {
+  message: string;
+  user: UserInfo & { id: number };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,13 @@ export type PostTaskRequired = {
   due_date: Date;
 };
 
+export type AuthUserData = {
+  id: number;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+};
+
 export type UserInfo = {
   username: string;
   first_name: string;


### PR DESCRIPTION
Issue: #19 

This PR creates a signup page at `/signup`. If the user is already logged in, they are directed to log out or go back home. If they are not logged in, they are presented with a controlled form to provide first name, last name, username, email, and password information, which sends a POST request to the backend to create the user. After account creation, they are directed to log in. 

The PR also creates a button for users without an account to go right to the signup page from the login page. For the login page, it also adds an `AuthUserData` type to replace `any` and makes minor formatting changes. 
