### PR TITLE
22 task by

### DIFF
--- a/src/components/TaskArea/TaskList/TaskList.tsx
+++ b/src/components/TaskArea/TaskList/TaskList.tsx
@@ -38,7 +38,7 @@ const TaskList: React.FC<TaskListProps> = ({ taskType, addingTask }) => {
   useEffect(() => {
       console.log('Retrieved User:', user);
       if (user) {
-        sendRequest({ task_type: taskType, user_id: user.id});
+        sendRequest({ task_type: taskType, user_id: String(user.id)});
       // Depend on addingTask so that the list will update when a new task is added
       }
   }, [sendRequest, taskType, addingTask, user]);

--- a/src/components/TaskArea/TaskList/TaskList.tsx
+++ b/src/components/TaskArea/TaskList/TaskList.tsx
@@ -3,21 +3,45 @@ import useGetRequest from '../../../hooks/useGetRequest';
 import { TaskData, TaskType } from '../../../types';
 import styles from './TaskList.module.css';
 import TaskBox from './TaskBox';
+import AuthService from '../../../utils/Auth';
+import { AuthUserData } from '../../../types';
+import { bool } from 'three/tsl';
 
 type TaskListProps = {
   taskType: TaskType;
   addingTask: boolean;
-};
+}
 
 const TaskList: React.FC<TaskListProps> = ({ taskType, addingTask }) => {
   const [tasks, setTasks] = useState<TaskData[] | null>(null);
   const { data, error, loading, sendRequest } = useGetRequest<TaskData[]>('tasks');
+  const [user, setUser] = useState<AuthUserData | null>(null);
 
-  // Initially get the tasks
+  // Check if user is logged in
   useEffect(() => {
-    sendRequest({ task_type: taskType });
-    // Depend on addingTask so that the list will update when a new task is added
-  }, [sendRequest, taskType, addingTask]);
+    async function getUser() {
+    // const loggedInUser = AuthService.getUser();
+    const loggedInUser = AuthService.getUser();
+    console.log('Retrieved User:', loggedInUser);
+    // if (loggedInUser) {
+    //   setUser(loggedInUser);
+    // } 
+    
+      setUser(loggedInUser);
+    }
+
+    getUser();
+  // TODO: redirect to login page if user is not logged in
+  }, []);
+
+  // Initially get the tasks 
+  useEffect(() => {
+      console.log('Retrieved User:', user);
+      if (user) {
+        sendRequest({ task_type: taskType, user_id: user.id});
+      // Depend on addingTask so that the list will update when a new task is added
+      }
+  }, [sendRequest, taskType, addingTask, user]);
 
   // Set the initial tasks to local state
   useEffect(() => {


### PR DESCRIPTION
Resolves #22 

Previously, tasks for all users were displayed, whether or not the user was logged in. This changes the task fetching functionality so that tasks aren't grabbed until a valid user is loaded, and only tasks for that user are grabbed. 
If the user is not logged in, no tasks are displayed.
