### PR TITLE
20 account page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import TaskPage from './pages/TaskPage/TaskPage';
 import LoginPage from './pages/LoginPage/LoginPage';
 import SignupPage from './pages/SignupPage/SignupPage';
+import AccountPage from './pages/AccountPage/AccountPage';
 
 const App = () => {
   return (
@@ -11,6 +12,7 @@ const App = () => {
         <Route path='/' element={<TaskPage />} />
         <Route path='/login' element={<LoginPage />} />
         <Route path='/signup' element={<SignupPage />} />
+        <Route path='/account' element={<AccountPage />} />
       </Routes>
     </Router>
   );

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -1,0 +1,67 @@
+import { useNavigate } from 'react-router-dom';
+import AuthService from '../../utils/Auth';
+import { AuthUserData, UserInfoField } from '../../types';
+import { useEffect, useState } from 'react';
+import InfoUpdateForm from './InfoUpdateForm';
+import DeleteAccount from './DeleteAccount';
+
+const AccountPage = () => {
+  const [user, setUser] = useState<AuthUserData | null>(null);
+  const [token, setToken] = useState('');
+  const [updatingInfo, setUpdatingInfo] = useState<UserInfoField | null>(null);
+  const navigate = useNavigate();
+
+  // Try to get the user. If they are not logged in, redirect to the login page.
+  useEffect(() => {
+    const loggedInUser = AuthService.getUser();
+    const retrievedToken = AuthService.getToken();
+    if (loggedInUser && retrievedToken) {
+      setUser(loggedInUser);
+      setToken(retrievedToken);
+    } else {
+      navigate('/login');
+    }
+  }, [navigate, updatingInfo]);
+
+  return (
+    user && (
+      <>
+        <h2>Hello, {user.first_name}!</h2>
+        <br />
+        {updatingInfo ? (
+          <InfoUpdateForm field={updatingInfo} setUpdatingInfo={setUpdatingInfo} token={token} />
+        ) : (
+          <>
+            <button type='button' onClick={() => setUpdatingInfo('username')}>
+              Change username
+            </button>
+            <br />
+            <button type='button' onClick={() => setUpdatingInfo('first_name')}>
+              Change first name
+            </button>
+            <br />
+            <button type='button' onClick={() => setUpdatingInfo('last_name')}>
+              Change last name
+            </button>
+            <br />
+            <button type='button' onClick={() => setUpdatingInfo('email')}>
+              Change email
+            </button>
+            <br />
+            <button type='button' onClick={() => setUpdatingInfo('password')}>
+              Change password
+            </button>
+            <br />
+            <button type='button' onClick={() => AuthService.logout()}>
+              Log out
+            </button>
+            <br />
+            <DeleteAccount token={token} />
+          </>
+        )}
+      </>
+    )
+  );
+};
+
+export default AccountPage;

--- a/src/pages/AccountPage/DeleteAccount.tsx
+++ b/src/pages/AccountPage/DeleteAccount.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import usePostPutPatchDelete from '../../hooks/usePostPutPatchDelete';
+import AuthService from '../../utils/Auth';
+
+const DeleteAccount: React.FC<{ token: string }> = ({ token }) => {
+  const { data, error, loading, sendRequest } = usePostPutPatchDelete<
+    undefined, // No body for DELETE
+    { message: string }
+  >('user', 'DELETE', { Authorization: `Bearer ${token}` });
+
+  // Automatically redirect 2.5s after successful deletion
+  useEffect(() => {
+    if (data) {
+      const timer = setTimeout(() => AuthService.logout(), 2500);
+      return () => clearTimeout(timer); // Cleanup in case the component unmounts early
+    }
+  }, [data]);
+
+  return (
+    <>
+      <h3>DANGER ZONE</h3>
+      {/* No body for DELETE */}
+      <button type='button' onClick={() => sendRequest(undefined)}>
+        Delete account
+      </button>
+      {loading && <p>Loading...</p>}
+      {error && <p>Failed to delete account: {error.message}</p>}
+      {data && <p>Successfully deleted account, redirecting...</p>}
+    </>
+  );
+};
+
+export default DeleteAccount;

--- a/src/pages/AccountPage/DeleteAccount.tsx
+++ b/src/pages/AccountPage/DeleteAccount.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import usePostPutPatchDelete from '../../hooks/usePostPutPatchDelete';
 import AuthService from '../../utils/Auth';
 
 const DeleteAccount: React.FC<{ token: string }> = ({ token }) => {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const { data, error, loading, sendRequest } = usePostPutPatchDelete<
     undefined, // No body for DELETE
     { message: string }
@@ -19,10 +20,23 @@ const DeleteAccount: React.FC<{ token: string }> = ({ token }) => {
   return (
     <>
       <h3>DANGER ZONE</h3>
-      {/* No body for DELETE */}
-      <button type='button' onClick={() => sendRequest(undefined)}>
+      <button type='button' onClick={() => setConfirmingDelete(true)}>
         Delete account
       </button>
+      {confirmingDelete && (
+        <>
+          <p>
+            <strong>Are you SURE you want to delete your account?</strong>
+          </p>
+          {/* No body for DELETE */}
+          <button type='button' onClick={() => sendRequest(undefined)}>
+            Yes, delete
+          </button>
+          <button type='button' onClick={() => setConfirmingDelete(false)}>
+            No, cancel deletion
+          </button>
+        </>
+      )}
       {loading && <p>Loading...</p>}
       {error && <p>Failed to delete account: {error.message}</p>}
       {data && <p>Successfully deleted account, redirecting...</p>}

--- a/src/pages/AccountPage/InfoUpdateForm.tsx
+++ b/src/pages/AccountPage/InfoUpdateForm.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import usePostPutPatchDelete from '../../hooks/usePostPutPatchDelete';
+import { UserInfoField, UserSignupUpdateResponse } from '../../types';
+import AuthService from '../../utils/Auth';
+
+type InfoUpdateFormProps = {
+  field: UserInfoField;
+  setUpdatingInfo: (updatingInfo: UserInfoField | null) => void;
+  token: string;
+};
+
+const InfoUpdateForm: React.FC<InfoUpdateFormProps> = ({ field, setUpdatingInfo, token }) => {
+  const [newInfo, setNewInfo] = useState('');
+  const { data, error, loading, sendRequest } = usePostPutPatchDelete<
+    Record<UserInfoField, string>,
+    UserSignupUpdateResponse
+  >('user', 'PATCH', { Authorization: `Bearer ${token}` });
+
+  // Automatically log out 2.5s after successful update (causes redirect)
+  useEffect(() => {
+    if (data) {
+      const timer = setTimeout(() => AuthService.logout(), 2500);
+      return () => clearTimeout(timer); // Cleanup in case the component unmounts early
+    }
+  }, [data]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Determining this is type safe because field is constrained to be a non-null UserInfoField
+    sendRequest({ [field]: newInfo } as Record<UserInfoField, string>);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <label>
+          New {field}:{' '}
+          <input
+            value={newInfo}
+            onChange={(e) => setNewInfo(e.target.value)}
+            type={field === 'email' || field === 'password' ? field : 'text'}
+            required
+            autoFocus
+          />
+        </label>
+        <br />
+        <button type='submit'>Submit</button>
+        <button type='button' onClick={() => setUpdatingInfo(null)}>
+          Cancel
+        </button>
+      </form>
+      {loading && <p>Loading...</p>}
+      {error && <p>Failed to update info: {error.message}</p>}
+      {data && <p>Successfully updated {field}, redirecting...</p>}
+      <br />
+    </>
+  );
+};
+
+export default InfoUpdateForm;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,8 @@ export type AuthUserData = {
   last_name?: string;
 };
 
+export type UserInfoField = 'username' | 'first_name' | 'last_name' | 'email' | 'password';
+
 export type UserInfo = {
   username: string;
   first_name: string;


### PR DESCRIPTION
Issue: #20 

This PR adds the account page at `/account`. On this page, the user can update their first name, last name, username, email, or password. They can also delete their account (after a confirmation). 

### Redirect behavior 

The current redirect behavior is not exactly ideal, but likely should be solved in a separate issue. Currently, after a user updates their info, `AuthService.logout()` is called, which redirects to the root route. Really, they should be redirected to the login page. However, the root route will eventually redirect to the login page if the user is not logged in, so it is probably better to keep this behavior for the purposes of this PR and then later update the root route redirection behavior (instead of complicating things with a temporary custom logout function). 