### PR TITLE
24 navbar routes redirects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,15 +4,18 @@ import TaskPage from './pages/TaskPage/TaskPage';
 import LoginPage from './pages/LoginPage/LoginPage';
 import SignupPage from './pages/SignupPage/SignupPage';
 import AccountPage from './pages/AccountPage/AccountPage';
+import MainLayout from './layouts/MainLayout';
 
 const App = () => {
   return (
     <Router>
       <Routes>
-        <Route path='/' element={<TaskPage />} />
-        <Route path='/login' element={<LoginPage />} />
-        <Route path='/signup' element={<SignupPage />} />
-        <Route path='/account' element={<AccountPage />} />
+        <Route element={<MainLayout />}>
+          <Route path='/' element={<TaskPage />} />
+          <Route path='/login' element={<LoginPage />} />
+          <Route path='/signup' element={<SignupPage />} />
+          <Route path='/account' element={<AccountPage />} />
+        </Route>
       </Routes>
     </Router>
   );

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,0 +1,3 @@
+.navList > li > * {
+  color: lightseagreen;
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+import styles from './Header.module.css';
+
+const Header = () => {
+  return (
+    <header>
+      <h1>Taskagotchi</h1>
+      <nav>
+        <ul className={styles.navList}>
+          <li>
+            <Link to='/'>Home</Link>
+          </li>
+          <li>
+            <Link to='/account'>Account</Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from 'react-router-dom';
+import Header from '../components/Header/Header';
+
+const MainLayout = () => {
+  return (
+    <>
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+    </>
+  );
+};
+
+export default MainLayout;

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -1,12 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 import AuthService from '../../utils/Auth';
-import { AuthUserData, UserInfoField } from '../../types';
+import { AuthUserData, UserInfo, UserInfoField } from '../../types';
 import { useEffect, useState } from 'react';
 import InfoUpdateForm from './InfoUpdateForm';
 import DeleteAccount from './DeleteAccount';
 
 const AccountPage = () => {
-  const [user, setUser] = useState<AuthUserData | null>(null);
+  const [user, setUser] = useState<AuthUserData | UserInfo | null>(null);
   const [token, setToken] = useState('');
   const [updatingInfo, setUpdatingInfo] = useState<UserInfoField | null>(null);
   const navigate = useNavigate();
@@ -29,7 +29,12 @@ const AccountPage = () => {
         <h2>Hello, {user.first_name}!</h2>
         <br />
         {updatingInfo ? (
-          <InfoUpdateForm field={updatingInfo} setUpdatingInfo={setUpdatingInfo} token={token} />
+          <InfoUpdateForm
+            field={updatingInfo}
+            setUpdatingInfo={setUpdatingInfo}
+            token={token}
+            setUser={setUser}
+          />
         ) : (
           <>
             <button type='button' onClick={() => setUpdatingInfo('username')}>

--- a/src/pages/TaskPage/TaskPage.tsx
+++ b/src/pages/TaskPage/TaskPage.tsx
@@ -1,8 +1,18 @@
 import GameCanvas from '../../components/GameCanvas/GameCanvas';
 import TaskArea from '../../components/TaskArea/TaskArea';
 import styles from './TaskPage.module.css';
+import AuthService from '../../utils/Auth';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const TaskPage = () => {
+  const navigate = useNavigate();
+
+  // If the user is not logged in, redirect to the login page
+  useEffect(() => {
+    if (!AuthService.loggedIn()) navigate('/login');
+  }, [navigate]);
+
   return (
     <div className={styles.taskPageDiv}>
       <div className={styles.gameCanvasDiv}>


### PR DESCRIPTION
Issue: #24 

This PR achieves the following: 
- Redirect to the login page if the user is not logged in. 
- Set up a layout to wrap the routes so we can have persistent components like a header. 
- Create a basic header with a navigation bar. It is functional, but the styling should be improved later. Currently, the only places to go from the navbar are home and account. (Login appears automatically if the user is not logged in, and signup is linked to naturally from the login page.) 
- When a user updates their info, only log them out if they change their email or password. Otherwise, take them back home. 