### PR TITLE
28 immediately reflect account changes

### DIFF
--- a/src/components/TaskArea/TaskList/TaskList.tsx
+++ b/src/components/TaskArea/TaskList/TaskList.tsx
@@ -5,12 +5,11 @@ import styles from './TaskList.module.css';
 import TaskBox from './TaskBox';
 import AuthService from '../../../utils/Auth';
 import { AuthUserData } from '../../../types';
-import { bool } from 'three/tsl';
 
 type TaskListProps = {
   taskType: TaskType;
   addingTask: boolean;
-}
+};
 
 const TaskList: React.FC<TaskListProps> = ({ taskType, addingTask }) => {
   const [tasks, setTasks] = useState<TaskData[] | null>(null);
@@ -20,27 +19,16 @@ const TaskList: React.FC<TaskListProps> = ({ taskType, addingTask }) => {
   // Check if user is logged in
   useEffect(() => {
     async function getUser() {
-    // const loggedInUser = AuthService.getUser();
-    const loggedInUser = AuthService.getUser();
-    console.log('Retrieved User:', loggedInUser);
-    // if (loggedInUser) {
-    //   setUser(loggedInUser);
-    // } 
-    
+      const loggedInUser = AuthService.getUser();
       setUser(loggedInUser);
     }
-
     getUser();
-  // TODO: redirect to login page if user is not logged in
   }, []);
 
-  // Initially get the tasks 
+  // Initially get the tasks
   useEffect(() => {
-      console.log('Retrieved User:', user);
-      if (user) {
-        sendRequest({ task_type: taskType, user_id: String(user.id)});
-      // Depend on addingTask so that the list will update when a new task is added
-      }
+    if (user) sendRequest({ task_type: taskType, user_id: String(user.id) });
+    // Depend on addingTask so that the list will update when a new task is added
   }, [sendRequest, taskType, addingTask, user]);
 
   // Set the initial tasks to local state

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -21,7 +21,7 @@ const AccountPage = () => {
     } else {
       navigate('/login');
     }
-  }, [navigate, updatingInfo]);
+  }, [navigate]);
 
   return (
     user && (

--- a/src/pages/AccountPage/InfoUpdateForm.tsx
+++ b/src/pages/AccountPage/InfoUpdateForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import usePostPutPatchDelete from '../../hooks/usePostPutPatchDelete';
-import { AuthUserData, UserInfo, UserInfoField, UserSignupUpdateResponse } from '../../types';
+import { AuthUserData, UserInfo, UserInfoField, UserUpdateResponse } from '../../types';
 import AuthService from '../../utils/Auth';
 import { useNavigate } from 'react-router-dom';
 
@@ -21,7 +21,7 @@ const InfoUpdateForm: React.FC<InfoUpdateFormProps> = ({
   const navigate = useNavigate();
   const { data, error, loading, sendRequest } = usePostPutPatchDelete<
     Record<UserInfoField, string>,
-    UserSignupUpdateResponse
+    UserUpdateResponse
   >('user', 'PATCH', { Authorization: `Bearer ${token}` });
 
   // Automatically redirect or log out 2.5s after successful update
@@ -31,8 +31,8 @@ const InfoUpdateForm: React.FC<InfoUpdateFormProps> = ({
       const timer = setTimeout(() => {
         // Log out for email or password change
         if (field === 'email' || field === 'password') AuthService.logout();
-        // Redirect to home for username, first name, or last name change
-        else navigate('/');
+        // Update localStorage and redirect to home for username, first name, or last name change
+        else AuthService.login(data.token);
       }, 2500);
       return () => clearTimeout(timer); // Cleanup in case the component unmounts early
     }

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import AuthService from '../../utils/Auth';
 import { useState } from 'react';
 import usePostPutPatchDelete from '../../hooks/usePostPutPatchDelete';
-import { UserInfo, UserSignupUpdateResponse } from '../../types';
+import { UserInfo, SignupResponse } from '../../types';
 
 const SignupPage = () => {
   const navigate = useNavigate();
@@ -11,10 +11,10 @@ const SignupPage = () => {
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const { data, error, loading, sendRequest } = usePostPutPatchDelete<
-    UserInfo,
-    UserSignupUpdateResponse
-  >('signup', 'POST');
+  const { data, error, loading, sendRequest } = usePostPutPatchDelete<UserInfo, SignupResponse>(
+    'signup',
+    'POST',
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,9 @@ export type UserInfo = {
   password: string;
 };
 
-export type UserSignupUpdateResponse = {
+export type SignupResponse = {
   message: string;
   user: UserInfo & { id: number };
 };
+
+export type UserUpdateResponse = SignupResponse & { token: string };


### PR DESCRIPTION
Issue: #28 

This PR fixes the bug where user info would not be updated without a full log out and log in. The solution is to update the JWT in local storage without fully logging out. This requires the backend to send a new token back with user PUT/PATCH requests, so this PR depends on the related backend PR. 

Backend PR: https://github.com/CSPB3308-Team/productivity-backend/pull/37

Also, there were commented out lines of code and console.log statements left over from debugging `TaskList` that this PR removes (no functionality change). 