### PR TITLE
25 set up deployment

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,6 @@
+VITE_BACKEND_URL=put_the_URL_here
+
+# Create a file called .env.production in the root directory of the 
+# project, defining VITE_BACKEND_URL as above, replacing
+# `put_the_URL_here` with the actual backend URL. Do not include the
+# trailing slash.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 
 # Editor directories and files
+.vscode/
 .vscode/*
 !.vscode/extensions.json
 .idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@react-three/drei": "^10.0.4",
         "@react-three/fiber": "^9.0.4",
-        "@types/three": "^0.174.0",
         "jwt-decode": "^4.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -21,10 +20,12 @@
         "@eslint/js": "^9.19.0",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
+        "@types/three": "^0.174.0",
         "@vitejs/plugin-react": "^4.3.4",
         "eslint": "^9.19.0",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.18",
+        "gh-pages": "^6.3.0",
         "globals": "^15.14.0",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.22.0",
@@ -1912,6 +1913,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2106,6 +2124,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2201,6 +2236,19 @@
         "webgl-constants": "^1.1.1"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/draco3d": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
@@ -2213,6 +2261,13 @@
       "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.0",
@@ -2535,6 +2590,34 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2546,6 +2629,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
     "node_modules/find-up": {
@@ -2586,6 +2687,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2609,6 +2725,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/gh-pages": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+      "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "commander": "^13.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^11.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/glob-parent": {
@@ -2637,11 +2776,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glsl-noise": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -2853,6 +3020,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jwt-decode": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
@@ -2935,6 +3115,22 @@
       "peerDependencies": {
         "@types/three": ">=0.134.0",
         "three": ">=0.134.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -3079,6 +3275,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3111,6 +3317,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3129,6 +3345,75 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/postcss": {
@@ -3460,6 +3745,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3507,6 +3802,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/supports-color": {
@@ -3580,6 +3898,29 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/troika-three-text": {
@@ -3716,6 +4057,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://CSPB3308-Team.github.io/taskagotchi/",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "npm run build && cp dist/index.html dist/404.html && gh-pages -d dist"
   },
   "dependencies": {
     "@react-three/drei": "^10.0.4",
     "@react-three/fiber": "^9.0.4",
-    "@types/three": "^0.174.0",
     "jwt-decode": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -23,10 +24,12 @@
     "@eslint/js": "^9.19.0",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
+    "@types/three": "^0.174.0",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.19.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
+    "gh-pages": "^6.3.0",
     "globals": "^15.14.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.22.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "homepage": "https://CSPB3308-Team.github.io/taskagotchi/",
+  "homepage": "https://cspb3308-team.github.io/productivity-frontend/",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './App.css';
 import TaskPage from './pages/TaskPage/TaskPage';
 import LoginPage from './pages/LoginPage/LoginPage';
@@ -8,7 +8,7 @@ import MainLayout from './layouts/MainLayout';
 
 const App = () => {
   return (
-    <Router>
+    <BrowserRouter basename='/taskagotchi'>
       <Routes>
         <Route element={<MainLayout />}>
           <Route path='/' element={<TaskPage />} />
@@ -17,7 +17,7 @@ const App = () => {
           <Route path='/account' element={<AccountPage />} />
         </Route>
       </Routes>
-    </Router>
+    </BrowserRouter>
   );
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import MainLayout from './layouts/MainLayout';
 
 const App = () => {
   return (
-    <BrowserRouter basename='/taskagotchi'>
+    <BrowserRouter basename='/productivity-frontend'>
       <Routes>
         <Route element={<MainLayout />}>
           <Route path='/' element={<TaskPage />} />

--- a/src/components/GameCanvas/Avatar.tsx
+++ b/src/components/GameCanvas/Avatar.tsx
@@ -1,8 +1,7 @@
 import { useGLTF } from '@react-three/drei'
-import * as THREE from 'three'
 
 export function Avatar(props: any) {
-  const { nodes, materials } = useGLTF('/Avatar.glb')
+  const { nodes } = useGLTF('/taskagotchi/Avatar.glb')
   
   return (
     <group {...props} name={"Avatar"} dispose={null}>
@@ -13,4 +12,4 @@ export function Avatar(props: any) {
   );
 }
 
-useGLTF.preload('/Capsule.glb')
+useGLTF.preload('/taskagotchi/Capsule.glb')

--- a/src/components/GameCanvas/Avatar.tsx
+++ b/src/components/GameCanvas/Avatar.tsx
@@ -1,7 +1,7 @@
 import { useGLTF } from '@react-three/drei'
 
 export function Avatar(props: any) {
-  const { nodes } = useGLTF('/taskagotchi/Avatar.glb')
+  const { nodes } = useGLTF('/productivity-frontend/Avatar.glb')
   
   return (
     <group {...props} name={"Avatar"} dispose={null}>
@@ -12,4 +12,4 @@ export function Avatar(props: any) {
   );
 }
 
-useGLTF.preload('/taskagotchi/Capsule.glb')
+useGLTF.preload('/productivity-frontend/Capsule.glb')

--- a/src/components/GameCanvas/Blur.tsx
+++ b/src/components/GameCanvas/Blur.tsx
@@ -2,7 +2,7 @@ import { useGLTF } from '@react-three/drei'
 import * as THREE from 'three'
 
 export function Blur(props: any) {
-  const { nodes } = useGLTF('/taskagotchi/RoomFloor.glb')
+  const { nodes } = useGLTF('/productivity-frontend/RoomFloor.glb')
 
   // create a material texture that emulates a blur effect
   function blurMat() {
@@ -27,4 +27,4 @@ export function Blur(props: any) {
   )
 }
 
-useGLTF.preload('/taskagotchi/RoomWall.glb')
+useGLTF.preload('/productivity-frontend/RoomWall.glb')

--- a/src/components/GameCanvas/Blur.tsx
+++ b/src/components/GameCanvas/Blur.tsx
@@ -2,11 +2,11 @@ import { useGLTF } from '@react-three/drei'
 import * as THREE from 'three'
 
 export function Blur(props: any) {
-  const { nodes } = useGLTF('/RoomFloor.glb')
+  const { nodes } = useGLTF('/taskagotchi/RoomFloor.glb')
 
   // create a material texture that emulates a blur effect
   function blurMat() {
-    var new_mat = new THREE.MeshPhysicalMaterial( {
+    const new_mat = new THREE.MeshPhysicalMaterial( {
       color: 0x8cd3ff,
       transmission: 1,
       opacity: 1,
@@ -27,4 +27,4 @@ export function Blur(props: any) {
   )
 }
 
-useGLTF.preload('/RoomWall.glb')
+useGLTF.preload('/taskagotchi/RoomWall.glb')

--- a/src/components/GameCanvas/GameCanvas.tsx
+++ b/src/components/GameCanvas/GameCanvas.tsx
@@ -18,7 +18,7 @@ import InventoryMenu from './InventoryMenu';
 import InventoryPreview from './InventoryPreview';
 
 export default function GameCanvas() {
-  var devMode = false;
+  const devMode = false;
 
   const user = useContext(UserContext);
 
@@ -80,7 +80,7 @@ export default function GameCanvas() {
 
   // Testing changing the color / opacity of an object
   const colorChange = (event: any) => {
-    var new_mat = event.object.material.clone();
+    const new_mat = event.object.material.clone();
     new_mat.color.setHex(0xA3C197);
     new_mat.transparent = true; // transparent must be "true" for opacity to do anything
     new_mat.opacity = Number(!event.object.material.opacity); // switches opacity between 0 and 1

--- a/src/components/GameCanvas/InventoryMenu.tsx
+++ b/src/components/GameCanvas/InventoryMenu.tsx
@@ -4,7 +4,6 @@ import CurrencyIcon from './CurrencyIcon';
 import useGetRequest from '../../hooks/useGetRequest';
 import { AuthUserData, ItemUserData } from '../../types';
 import { BalanceContext } from '../../pages/TaskPage/TaskPage';
-import { select } from 'three/tsl';
 
 interface ItemInputs {
   user?: AuthUserData
@@ -15,7 +14,7 @@ export default function InventoryMenu(inData: ItemInputs) {
   const { userBalance, setUserBalance } = useContext(BalanceContext);
 
   // GET Request: item data from database
-  const { data, error, loading, sendRequest } = useGetRequest<ItemUserData[]>('items');
+  const { data, sendRequest } = useGetRequest<ItemUserData[]>('items');
   const [itemData, setItemData] = useState<ItemUserData[] | null>(null);  // stores item manifest
   const [invTab, setInvTab] = useState(0);                                // handle switching inventory tabs
   const [tabColor, setTabColor] = useState([true, false, false]);         // manage styles to change color on selection
@@ -28,7 +27,7 @@ export default function InventoryMenu(inData: ItemInputs) {
   // get initial item table
   useEffect(() => {
     if (user) sendRequest({ user_id: String(user.id) });
-  }, [sendRequest]);
+  }, [sendRequest, user]);
 
   // Add the items to local state
   useEffect(() => {
@@ -38,7 +37,7 @@ export default function InventoryMenu(inData: ItemInputs) {
   // switch the active tab for filtering and styling
   function updateInvTab(invType: number) {
     console.log("Item Data", data);
-    let tabTemp = tabColor;
+    const tabTemp = tabColor;
     tabTemp[invTab] = false;
     tabTemp[invType] = true;
 
@@ -71,8 +70,8 @@ export default function InventoryMenu(inData: ItemInputs) {
       setUserBalance((userBalance as number) - (selectedItem as ItemUserData).item_cost);
       setShowPurchase(false);
 
-      let tempItems = itemData;
-      let selection = tempItems.find((item) => item.id == selectedItem.id);
+      const tempItems = itemData;
+      const selection = tempItems.find((item) => item.id == selectedItem.id);
       
       Object.assign(selection as ItemUserData, {...selectedItem, owned: true})
       
@@ -105,7 +104,7 @@ export default function InventoryMenu(inData: ItemInputs) {
       }
 
       // make a new array with just those items
-      let tab_items = itemData.filter((item) => item.item_type === i_type);
+      const tab_items = itemData.filter((item) => item.item_type === i_type);
 
       // map those items into some html
       const item_grid = tab_items.map((item, idx) =>

--- a/src/components/GameCanvas/InventoryPreview.tsx
+++ b/src/components/GameCanvas/InventoryPreview.tsx
@@ -34,7 +34,7 @@ export default function InventoryPreview(dress: DressUp) {
 
       // Offset clone's position so it's well-framed for dressing up
       // create a vector to hold the clone's distance from the camera
-      let avPos = new THREE.Vector3(AV_POS_X, AV_POS_Y, AV_POS_Z);
+      const avPos = new THREE.Vector3(AV_POS_X, AV_POS_Y, AV_POS_Z);
 
       // convert the local displacement to the world reference frame
       camera.localToWorld(avPos);
@@ -45,7 +45,7 @@ export default function InventoryPreview(dress: DressUp) {
       av_c.position.z = avPos.z;
 
       // Match the clone's rotation to the camera's rotation
-      let camQuat = new THREE.Quaternion();
+      const camQuat = new THREE.Quaternion();
       camera.getWorldQuaternion(camQuat);
       av_c.applyQuaternion(camQuat);
 
@@ -69,7 +69,7 @@ export default function InventoryPreview(dress: DressUp) {
       dressLight1.decay = 0;
 
       // Set the light's offset relative to the camera/clone
-      let lightPos1 = new THREE.Vector3(10, -5, 5);
+      const lightPos1 = new THREE.Vector3(10, -5, 5);
       camera.localToWorld(lightPos1);
 
       dressLight1.position.x = lightPos1.x;
@@ -90,7 +90,7 @@ export default function InventoryPreview(dress: DressUp) {
       dressLight2.intensity = 5;
       dressLight2.decay = 0;
 
-      let lightPos2 = new THREE.Vector3(-10, 5, 5);
+      const lightPos2 = new THREE.Vector3(-10, 5, 5);
       camera.localToWorld(lightPos2);
 
       dressLight2.position.x = lightPos2.x;

--- a/src/components/GameCanvas/RoomFloor.tsx
+++ b/src/components/GameCanvas/RoomFloor.tsx
@@ -1,8 +1,8 @@
-import { useGLTF } from '@react-three/drei'
-import * as THREE from 'three'  
+import { useGLTF } from '@react-three/drei';
+import * as THREE from 'three';
 
 export function RoomFloor(props: any) {
-  const { nodes, materials } = useGLTF('/taskagotchi/RoomFloor.glb')
+  const { nodes, materials } = useGLTF('/productivity-frontend/RoomFloor.glb');
   return (
     <group {...props} dispose={null}>
       <mesh
@@ -12,7 +12,7 @@ export function RoomFloor(props: any) {
         material={materials.Material}
       />
     </group>
-  )
+  );
 }
 
-useGLTF.preload('/taskagotchi/RoomFloor.glb')
+useGLTF.preload('/productivity-frontend/RoomFloor.glb');

--- a/src/components/GameCanvas/RoomFloor.tsx
+++ b/src/components/GameCanvas/RoomFloor.tsx
@@ -2,7 +2,7 @@ import { useGLTF } from '@react-three/drei'
 import * as THREE from 'three'  
 
 export function RoomFloor(props: any) {
-  const { nodes, materials } = useGLTF('/RoomFloor.glb')
+  const { nodes, materials } = useGLTF('/taskagotchi/RoomFloor.glb')
   return (
     <group {...props} dispose={null}>
       <mesh
@@ -15,4 +15,4 @@ export function RoomFloor(props: any) {
   )
 }
 
-useGLTF.preload('/RoomFloor.glb')
+useGLTF.preload('/taskagotchi/RoomFloor.glb')

--- a/src/components/GameCanvas/RoomWall.tsx
+++ b/src/components/GameCanvas/RoomWall.tsx
@@ -2,7 +2,7 @@ import { useGLTF } from '@react-three/drei'
 import * as THREE from 'three'  
 
 export function RoomWall(props: any) {
-  const { nodes, materials } = useGLTF('/RoomWall.glb')
+  const { nodes, materials } = useGLTF('/taskagotchi/RoomWall.glb')
   return (
     <group {...props} dispose={null}>
       <mesh
@@ -16,4 +16,4 @@ export function RoomWall(props: any) {
   )
 }
 
-useGLTF.preload('/RoomWall.glb')
+useGLTF.preload('/taskagotchi/RoomWall.glb')

--- a/src/components/GameCanvas/RoomWall.tsx
+++ b/src/components/GameCanvas/RoomWall.tsx
@@ -1,8 +1,8 @@
-import { useGLTF } from '@react-three/drei'
-import * as THREE from 'three'  
+import { useGLTF } from '@react-three/drei';
+import * as THREE from 'three';
 
 export function RoomWall(props: any) {
-  const { nodes, materials } = useGLTF('/taskagotchi/RoomWall.glb')
+  const { nodes, materials } = useGLTF('/productivity-frontend/RoomWall.glb');
   return (
     <group {...props} dispose={null}>
       <mesh
@@ -10,10 +10,9 @@ export function RoomWall(props: any) {
         receiveShadow
         geometry={(nodes.Plane as THREE.Mesh).geometry}
         material={materials.Material}
-        
       />
     </group>
-  )
+  );
 }
 
-useGLTF.preload('/taskagotchi/RoomWall.glb')
+useGLTF.preload('/productivity-frontend/RoomWall.glb');

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -36,7 +36,7 @@ const LoginPage = () => {
       AuthService.login(response.token);
       setUser(AuthService.getUser());
       // Redirect to home
-      navigate('/');
+      navigate('/productivity-frontend');
     } else {
       setError('Invalid email or password');
     }

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -36,7 +36,7 @@ const SignupPage = () => {
         <button type='button' onClick={() => AuthService.logout()}>
           Log out
         </button>
-        <button type='button' onClick={() => navigate('/')}>
+        <button type='button' onClick={() => navigate('/productivity-frontend')}>
           Back home
         </button>
       </>

--- a/src/pages/TaskPage/TaskPage.tsx
+++ b/src/pages/TaskPage/TaskPage.tsx
@@ -12,16 +12,15 @@ interface BalanceContextType {
   setUserBalance: Dispatch<SetStateAction<number | null>>;
 }
 
-
 // lets us pass user data to all child components
 export const UserContext = createContext<AuthUserData | null>(null);
 export const BalanceContext = createContext<BalanceContextType>({
   userBalance: null,
-  setUserBalance: () => { }
+  setUserBalance: () => {},
 });
 
 const TaskPage = () => {
-  const { data, error, loading, sendRequest } = useGetRequest<BalanceData>('balance', true);
+  const { data, sendRequest } = useGetRequest<BalanceData>('balance', true);
   const navigate = useNavigate();
 
   const [user, setUser] = useState<AuthUserData | null>(null);
@@ -45,14 +44,12 @@ const TaskPage = () => {
   useEffect(() => {
     if (user) {
       sendRequest({});
-      console.log('Send Request:', data)
     }
-  }, [user, sendRequest]);
+  }, [user, sendRequest, data]);
 
   // Add initial balance to state
   useEffect(() => {
     if (data) setUserBalance(data.balance);
-    console.log('Balance Data: ', data)
   }, [data, setUserBalance]);
 
   return (

--- a/src/pages/TaskPage/TaskPage.tsx
+++ b/src/pages/TaskPage/TaskPage.tsx
@@ -45,7 +45,7 @@ const TaskPage = () => {
     if (user) {
       sendRequest({});
     }
-  }, [user, sendRequest, data]);
+  }, [user, sendRequest]);
 
   // Add initial balance to state
   useEffect(() => {

--- a/src/utils/Auth.tsx
+++ b/src/utils/Auth.tsx
@@ -28,12 +28,12 @@ class AuthService {
 // Sets the token in local storage, then redirects
   login(idToken: string): void {
     localStorage.setItem("id_token", idToken);
-    window.location.assign("/");
+    window.location.assign("/productivity-frontend");
   }
 // Removes the token from local storage, then redirects
 logout(): void {
     localStorage.removeItem("id_token");
-    window.location.assign("/");
+    window.location.assign("/productivity-frontend");
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/taskagotchi/', // The organization site root
+  base: '/productivity-frontend/', // The repo name
   plugins: [react()],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/taskagotchi/', // The organization site root
   plugins: [react()],
-})
+});


### PR DESCRIPTION
Issue: #25 

This is the PR for deploying the frontend. It is already deployed at https://cspb3308-team.github.io/productivity-frontend but these are the changes that the deployment required. 

Main changes: 
- Add the gh-pages package. This means you will need to run `npm install` so that the new package is added to your local `node_modules`. 
- Add the `npm run deploy` script, which includes the necessary workaround for client-side routing using GitHub Pages and React Router DOM. 
- In all places, the base path is now `/productivity-frontend` and then whatever the path previously was. Importantly, this includes redirects to home and paths to the glh files. 
- There were various syntax issues that needed fixing that seemed to be working in development but would not build, such as unused imports/variables and the header solution in useGetRequest. 
- Add `.env.production.example` because a local `.env.production` file with the real backend URL is necessary for deployment. 